### PR TITLE
makeadmin&auth

### DIFF
--- a/lib/mainpages/calendar.dart
+++ b/lib/mainpages/calendar.dart
@@ -35,11 +35,11 @@ class _CalendarState extends State<Calendar> {
     super.initState();
     _selectedDay = _focusedDay;
     _selectedEvents = ValueNotifier(_getEventsForDay(_selectedDay!));
-      _fetchAllEvents(widget.clubName).then((_) {
-    setState(() {
-      _isLoading = false; // 데이터 로딩 완료 표시
+    _fetchAllEvents(widget.clubName).then((_) {
+      setState(() {
+        _isLoading = false; // 데이터 로딩 완료 표시
+      });
     });
-  });
   }
 
   Future<void> _fetchAndSetEvents(DateTime day) async {
@@ -55,28 +55,28 @@ class _CalendarState extends State<Calendar> {
     _selectedEvents.value = loadedEvents;
   }
 
-Future<void> _fetchAllEvents(String club) async {
-  final snapshot = await FirebaseDatabase.instance
-      .ref("Club/$club/Calendar")
-      .get();
+  Future<void> _fetchAllEvents(String club) async {
+    final snapshot = await FirebaseDatabase.instance
+        .ref("Club/$club/Calendar")
+        .get();
 
-  if (snapshot.exists) {
-    final data = snapshot.value as Map<dynamic, dynamic>;
+    if (snapshot.exists) {
+      final data = snapshot.value as Map<dynamic, dynamic>;
 
-    data.forEach((dateStr, value) {
-      DateTime date = DateTime.parse(dateStr);
-      List<Event> eventList = [];
+      data.forEach((dateStr, value) {
+        DateTime date = DateTime.parse(dateStr);
+        List<Event> eventList = [];
 
-      if (value is List) {
-        eventList = value.map((e) => Event(e.toString())).toList();
-      } else if (value is Map) {
-        eventList = value.values.map((e) => Event(e.toString())).toList();
-      }
+        if (value is List) {
+          eventList = value.map((e) => Event(e.toString())).toList();
+        } else if (value is Map) {
+          eventList = value.values.map((e) => Event(e.toString())).toList();
+        }
 
-      events[DateTime.utc(date.year, date.month, date.day)] = eventList;
-    });
+        events[DateTime.utc(date.year, date.month, date.day)] = eventList;
+      });
+    }
   }
-}
 
 
 

--- a/lib/services/AuthService.dart
+++ b/lib/services/AuthService.dart
@@ -62,3 +62,57 @@ Future<String> user_status(String clubName) async {
     return "You are a memeber."; 
   }
 }
+
+
+class OfficerService {
+  /// 현재 사용자 학번
+  static Future<String?> currentStudentId() async {
+    try {
+      return await user_stuid(); // 이미 구현되어 있다고 하셨음
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// officer role: 'president' | 'vice' | 'manager' | 'none'
+  static Future<String> roleOf(String clubName) async {
+    final sid = await currentStudentId();
+    if (sid == null) return 'none';
+
+    final snap = await FirebaseDatabase.instance
+        .ref('Club/$clubName/officer')
+        .get();
+
+    if (!snap.exists) return 'none';
+
+    final data = Map<dynamic, dynamic>.from(snap.value as Map);
+
+    // 1) president/vice 직속 키 매칭
+    final president = data['president']?.toString();
+    if (president == sid) return 'president';
+
+    final vice = data['vice']?.toString();
+    if (vice == sid) return 'vice';
+
+    // 2) manager 패턴 (manager1, manager2, ...), 또는 managers 맵 지원
+    // (1) managerN 키들
+    for (final e in data.entries) {
+      final k = e.key.toString();
+      if (k.startsWith('manager') && e.value?.toString() == sid) {
+        return 'manager';
+      }
+    }
+    // (2) managers: { "sid": true, ... } 형태도 지원
+    if (data['managers'] is Map) {
+      final managers = Map<dynamic, dynamic>.from(data['managers']);
+      if (managers.containsKey(sid) && managers[sid] == true) return 'manager';
+    }
+
+    return 'none';
+  }
+
+  static Future<bool> canManage(String clubName) async {
+    final r = await roleOf(clubName);
+    return r == 'president' || r == 'vice' || r == 'manager';
+  }
+}


### PR DESCRIPTION
운영진을 추가했습니다.
운영진은
Club/
 └─ {clubName}/
     └─ officer/
          └─ president: "2021312381"
          └─ vice: "2021123456"
          └─ manager1: "2021000000"
          └─ manager2: "2021111111"
이런 식의 db로 설계했습니다.

이번 커밋은 공지 게시판에 공지를 생성, 수정, 삭제할 수 있는 권한을 운영진에게만 부여되도록 개발하였습니다.

추가해야 하는 기능: 회장/부회장 위임(회원 리스트 생성 후), 캘린더 생성, 수정, 삭제 권한, 부원 가입 수락, 동아리 정보 변경 등이 있습니다.